### PR TITLE
Add facets and terms

### DIFF
--- a/.idea/galc-api.iml
+++ b/.idea/galc-api.iml
@@ -70,7 +70,7 @@
     <orderEntry type="library" scope="PROVIDED" name="http-cookie (v1.0.4, RVM: ruby-3.0.3) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="i18n (v1.10.0, RVM: ruby-3.0.3) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="jsonapi-serializer (v2.2.0, RVM: ruby-3.0.3) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="jsonapi.rb (v1.7.0, RVM: ruby-3.0.3) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="jsonapi.rb (v2.0.0, RVM: ruby-3.0.3) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="lograge (v0.12.0, RVM: ruby-3.0.3) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="loofah (v2.16.0, RVM: ruby-3.0.3) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="mail (v2.7.1, RVM: ruby-3.0.3) [gem]" level="application" />
@@ -105,7 +105,6 @@
     <orderEntry type="library" scope="PROVIDED" name="railties (v7.0.2.3, RVM: ruby-3.0.3) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rainbow (v3.1.1, RVM: ruby-3.0.3) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rake (v13.0.6, RVM: ruby-3.0.3) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="ransack (v3.0.0, RVM: ruby-3.0.3) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="regexp_parser (v2.2.1, RVM: ruby-3.0.3) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="request_store (v1.5.1, RVM: ruby-3.0.3) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rest-client (v2.1.0, RVM: ruby-3.0.3) [gem]" level="application" />

--- a/.idea/galc-api.iml
+++ b/.idea/galc-api.iml
@@ -15,7 +15,6 @@
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/features" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.bundle" />
       <excludeFolder url="file://$MODULE_DIR$/public/packs" />

--- a/.idea/galc-api.iml
+++ b/.idea/galc-api.iml
@@ -105,6 +105,7 @@
     <orderEntry type="library" scope="PROVIDED" name="railties (v7.0.2.3, RVM: ruby-3.0.3) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rainbow (v3.1.1, RVM: ruby-3.0.3) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rake (v13.0.6, RVM: ruby-3.0.3) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="ransack (v2.6.0, RVM: ruby-3.0.3) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="regexp_parser (v2.2.1, RVM: ruby-3.0.3) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="request_store (v1.5.1, RVM: ruby-3.0.3) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rest-client (v2.1.0, RVM: ruby-3.0.3) [gem]" level="application" />

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -9,6 +9,8 @@
     <inspection_tool class="GrazieInspection" enabled="false" level="TYPO" enabled_by_default="false" />
     <inspection_tool class="HttpUrlsUsage" enabled="true" level="INFORMATION" enabled_by_default="true" />
     <inspection_tool class="LanguageDetectionInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NonAsciiCharacters" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="RailsParamDefResolve" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="Rubocop" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="RubyCaseWithoutElseBlockInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="RubyInstanceMethodNamingConvention" enabled="false" level="WARNING" enabled_by_default="false" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="RVM: ruby-3.0.3" project-jdk-type="RUBY_SDK" />
+  <component name="ProjectRootManager" version="2" default="true" project-jdk-name="RVM: ruby-3.0.3" project-jdk-type="RUBY_SDK" />
 </project>

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'pg', '~> 1.2'
 gem 'puma', '~> 5.0'
 gem 'rack-cors'
 gem 'rails', '~> 7.0.2', '>= 7.0.2.3'
+gem 'ransack', '~> 2.6'
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '3.0.3'
 
 gem 'berkeley_library-logging', '~> 0.2', '>= 0.2.6'
 gem 'berkeley_library-util', '~> 0.1.1'
-gem 'jsonapi.rb', '~> 1.7'
+gem 'jsonapi.rb', '~> 2.0'
 gem 'jsonapi-serializer', '~> 2.2'
 gem 'omniauth-cas', '~> 2.0'
 gem 'pg', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,10 +118,9 @@ GEM
       concurrent-ruby (~> 1.0)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
-    jsonapi.rb (1.7.0)
+    jsonapi.rb (2.0.0)
       jsonapi-serializer
       rack
-      ransack
     lograge (0.12.0)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -212,10 +211,6 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    ransack (3.0.0)
-      activerecord (>= 6.0.4)
-      activesupport (>= 6.0.4)
-      i18n
     regexp_parser (2.2.1)
     request_store (1.5.1)
       rack (>= 1.4)
@@ -309,7 +304,7 @@ DEPENDENCIES
   factory_bot_rails
   hashdiff (~> 1.0.1)
   jsonapi-serializer (~> 2.2)
-  jsonapi.rb (~> 1.7)
+  jsonapi.rb (~> 2.0)
   omniauth-cas (~> 2.0)
   pg (~> 1.2)
   puma (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,10 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    ransack (2.6.0)
+      activerecord (>= 6.0.4)
+      activesupport (>= 6.0.4)
+      i18n
     regexp_parser (2.2.1)
     request_store (1.5.1)
       rack (>= 1.4)
@@ -310,6 +314,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-cors
   rails (~> 7.0.2, >= 7.0.2.3)
+  ransack (~> 2.6)
   rspec (~> 3.10)
   rspec-rails (~> 5.0)
   rspec_junit_formatter (~> 0.5)

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,8 @@ task setup: %w[db:await db:setup]
 
 desc 'Set up, check test coverage'
 task :check do
-  ENV['RAILS_ENV'] = 'test'
+  raise "Can't run specs; expected RAILS_ENV=\"test\", was #{Rails.env.inspect}" unless Rails.env.test?
+
   Rake::Task[:setup].invoke
   Rake::Task[:coverage].invoke
 end

--- a/app/controllers/concerns/exception_handlers.rb
+++ b/app/controllers/concerns/exception_handlers.rb
@@ -55,10 +55,11 @@ module ExceptionHandlers
       # :nocov:
     end
 
-    # @see JSONAPI::Errors.render_jsonapi_not_found
+    # Overrides JSONAPI::Errors.render_jsonapi_not_found to include error detail
     def render_jsonapi_not_found(exception)
       logger.error(exception)
-      super
+
+      render_jsonapi_error(:not_found, detail: exception.message)
     end
 
     # -----------------------------
@@ -70,12 +71,13 @@ module ExceptionHandlers
       return errors if errors.is_a?(Enumerable)
     end
 
-    def render_jsonapi_error(status)
+    def render_jsonapi_error(status, detail: nil)
       status_code = status_code(status)
       error = {
         status: status_code.to_s,
         title: Rack::Utils::HTTP_STATUS_CODES[status_code]
       }
+      error[:detail] = detail unless detail.nil?
       render(jsonapi_errors: [error], status: status_code)
     end
 

--- a/app/controllers/facets_controller.rb
+++ b/app/controllers/facets_controller.rb
@@ -1,0 +1,2 @@
+class FacetsController < ApplicationController
+end

--- a/app/controllers/facets_controller.rb
+++ b/app/controllers/facets_controller.rb
@@ -1,2 +1,6 @@
 class FacetsController < ApplicationController
+  def index
+    @facets = Facet.all
+    render jsonapi: @facets, include: [:terms]
+  end
 end

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -1,0 +1,2 @@
+class TermsController < ApplicationController
+end

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -1,2 +1,6 @@
 class TermsController < ApplicationController
+  def index
+    @terms = Term.all
+    render jsonapi: @terms
+  end
 end

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -1,0 +1,5 @@
+# A search facet.
+class Facet < ApplicationRecord
+  validates :name, presence: true
+  validates :name, uniqueness: true
+end

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -1,5 +1,14 @@
 # A search facet.
 class Facet < ApplicationRecord
+
+  # ------------------------------------------------------------
+  # Relations
+
+  has_many :terms, dependent: :destroy
+
+  # ------------------------------------------------------------
+  # Validations
+
   validates :name, presence: true
   validates :name, uniqueness: true
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,11 +1,21 @@
 class Item < ApplicationRecord
 
+  # ------------------------------------------------------------
+  # Constants
+
   ALL_ATTRS = Item.column_names.map(&:to_sym).freeze
   DATA_ATTRS = (ALL_ATTRS - [:id]).freeze
   EDIT_ATTRS = (DATA_ATTRS - %i[created_at updated_at]).freeze
 
-  validates :mms_id, uniqueness: { allow_nil: true }
+  # ------------------------------------------------------------
+  # Relations
 
+  has_and_belongs_to_many :terms
+
+  # ------------------------------------------------------------
+  # Validations
+
+  validates :mms_id, uniqueness: { allow_nil: true }
   validates :title, presence: true
 
   # TODO: figure out when we can enforce this

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,7 +5,7 @@ class Item < ApplicationRecord
 
   ALL_ATTRS = Item.column_names.map(&:to_sym).freeze
   DATA_ATTRS = (ALL_ATTRS - [:id]).freeze
-  EDIT_ATTRS = (DATA_ATTRS - %i[created_at updated_at]).freeze
+  EDIT_ATTRS = (DATA_ATTRS - %i[created_at updated_at] + [:terms]).freeze
 
   # ------------------------------------------------------------
   # Relations

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -1,14 +1,28 @@
 # A controlled vocabulary term.
 class Term < ApplicationRecord
-  belongs_to :facet
+
+  # ------------------------------------------------------------
+  # Relations
+
   has_many :children, class_name: 'Term', foreign_key: :parent_id, inverse_of: :parent, dependent: :destroy
   belongs_to :parent, class_name: 'Term', optional: true
+  has_and_belongs_to_many :items
+  belongs_to :facet
+
+  # ------------------------------------------------------------
+  # Validations
 
   validates :value, presence: true
   validates :value, uniqueness: true
   validate :parent_is_same_facet
 
+  # ------------------------------------------------------------
+  # Private methods
+
   private
+
+  # ------------------------------
+  # Validators
 
   def parent_is_same_facet
     return if parent.nil? || facet == parent.facet

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -1,0 +1,18 @@
+# A controlled vocabulary term.
+class Term < ApplicationRecord
+  belongs_to :facet
+  has_many :children, class_name: 'Term', foreign_key: :parent_id, inverse_of: :parent, dependent: :destroy
+  belongs_to :parent, class_name: 'Term', optional: true
+
+  validates :value, presence: true
+  validates :value, uniqueness: true
+  validate :parent_is_same_facet
+
+  private
+
+  def parent_is_same_facet
+    return if parent.nil? || facet == parent.facet
+
+    errors.add(:parent, "must be a #{facet.name}")
+  end
+end

--- a/app/serializers/facet_serializer.rb
+++ b/app/serializers/facet_serializer.rb
@@ -1,7 +1,7 @@
-class ItemSerializer
+class FacetSerializer
   include JSONAPI::Serializer
 
-  attributes(*Item::DATA_ATTRS)
+  attributes(:name)
 
   has_many :terms
 end

--- a/app/serializers/term_serializer.rb
+++ b/app/serializers/term_serializer.rb
@@ -4,4 +4,6 @@ class TermSerializer
   attributes(:value)
 
   belongs_to :facet
+  belongs_to :parent, serializer: TermSerializer, if: ->(term) { term.parent.present? }
+  has_many :children, serializer: TermSerializer, if: ->(term) { term.children.exists? }
 end

--- a/app/serializers/term_serializer.rb
+++ b/app/serializers/term_serializer.rb
@@ -1,0 +1,7 @@
+class TermSerializer
+  include JSONAPI::Serializer
+
+  attributes(:value)
+
+  belongs_to :facet
+end

--- a/config/initializers/jsonapi.rb
+++ b/config/initializers/jsonapi.rb
@@ -1,19 +1,3 @@
 require 'jsonapi'
 
 JSONAPI::Rails.install!
-
-# Monkey-patch to get around https://github.com/stas/jsonapi.rb/issues/75 pro tem
-module JSONAPI
-  module Rails
-    # rubocop:disable Naming/PredicateName
-    class << self
-      # @return [Boolean] true if it's an Enumerable that's not hash-like, false otherwise
-      def is_collection?(resource, force_is_collection = nil)
-        return force_is_collection unless force_is_collection.nil?
-
-        resource.is_a?(Enumerable) && !resource.respond_to?(:each_pair)
-      end
-    end
-    # rubocop:enable Naming/PredicateName
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,12 @@ Rails.application.routes.draw do
   get '/logout', to: 'sessions#logout', as: :logout
   get '/auth/:provider/callback', to: 'sessions#callback', as: :omniauth_callback
 
-  resources :items, defaults: { format: :jsonapi }, constraints: ->(req) { req.format == :jsonapi }
+  defaults format: :jsonapi do
+    constraints(->(req) { req.format == :jsonapi }) do
+      resources :items
+      resources :terms
+      resources :facets
+    end
+  end
+
 end

--- a/db/migrate/20220406213014_create_facets.rb
+++ b/db/migrate/20220406213014_create_facets.rb
@@ -1,0 +1,9 @@
+class CreateFacets < ActiveRecord::Migration[7.0]
+  def change
+    create_table :facets do |t|
+      t.string :name, null: false, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220406213252_create_terms.rb
+++ b/db/migrate/20220406213252_create_terms.rb
@@ -1,0 +1,11 @@
+class CreateTerms < ActiveRecord::Migration[7.0]
+  def change
+    create_table :terms do |t|
+      t.string :value, null: false, index: { unique: true }
+      t.references :facet, null: false, foreign_key: true
+      t.references :parent, null: true, foreign_key: {  to_table: :terms }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220414191138_populate_facets.rb
+++ b/db/migrate/20220414191138_populate_facets.rb
@@ -1,0 +1,113 @@
+# Ensure migration can run without error even if we delete/rename the models
+(class Facet < ActiveRecord::Base; end) unless defined?(Facet)
+(class Term < ActiveRecord::Base; end) unless defined?(Term)
+(class ItemsTerm < ActiveRecord::Base; end) unless defined?(ItemsTerm)
+
+# noinspection RubyLiteralArrayInspection
+class PopulateFacets < ActiveRecord::Migration[7.0]
+
+  FACETS = {
+    'Colors' => ['Color', 'Black and White'],
+    'Size' => ['Small', 'Medium', 'Large', 'Oversized'],
+    'Decade' =>
+      [
+        'Before 1900',
+        '1900-1909',
+        '1910-1919',
+        '1920-1929',
+        '1930-1939',
+        '1940-1949',
+        '1950-1959',
+        '1960-1969',
+        '1970-1979',
+        '1980-1989',
+        '1990-1999',
+        'After 1999',
+        'No Date'
+      ],
+    'Genre' =>
+      [
+        'Abstract', 'Animals', 'Cityscape', 'Figurative', 'Landscape', 'Pop Art', 'Religious', 'Still Life', 'Text Based'
+      ],
+    'Medium' =>
+      [
+        'Aquatint',
+        'Collage',
+        'Collagraph',
+        'Drypoint',
+        'Engraving',
+        'Etching',
+        'Giclée',
+        'Intaglio',
+        'Linocut',
+        'Lithograph',
+        'Mezzotint',
+        'Mixed Media',
+        'Monoprint',
+        'Monotype',
+        'Painting',
+        'Photograph',
+        'Photolithograph',
+        'Photoprint',
+        'Planographic',
+        'Relief',
+        'Relief Etching',
+        'Serigraph',
+        'Silkscreen',
+        'Stencil',
+        'Unidentified',
+        'Wood Engraving',
+        'Woodcut',
+        'Zincograph'
+      ] }
+
+  HIERARCHICAL_TERMS_BY_FACET = {
+    'Medium' => {
+      'Intaglio' => [
+        'Aquatint',
+        'Drypoint',
+        'Engraving',
+        'Etching',
+        'Mezzotint',
+        'Photoprint',
+        'Relief Etching'
+      ],
+      'Planographic' => [
+        'Lithograph',
+        'Photolithograph',
+        'Zincograph'
+      ],
+      'Relief' => [
+        'Collagraph',
+        'Linocut',
+        'Wood Engraving',
+        'Woodcut'
+      ],
+      'Stencil' => [
+        'Serigraph',
+        'Silkscreen'
+      ]
+    }
+  }
+
+  def up
+    FACETS.each do |f, tt|
+      facet = Facet.create(name: f)
+      tt.each { |t| Term.create(facet: facet, value: t) }
+    end
+
+    HIERARCHICAL_TERMS_BY_FACET.each do |f, terms_tree|
+      facet = Facet.find_by!(name: f)
+      terms_tree.each do |v_parent, v_children|
+        raise ArgumentError, "Missing term for #{facet.name} : #{v_parent}" unless (t_parent = Term.find_by(facet: facet, value: v_parent))
+        t_parent.children = v_children.map { |v_child| Term.find_by!(facet: facet, value: v_child) }
+      end
+    end
+  end
+
+  def down
+    Term.destroy_all
+    Facet.destroy_all
+  end
+end
+

--- a/db/migrate/20220414225150_create_join_table_item_term.rb
+++ b/db/migrate/20220414225150_create_join_table_item_term.rb
@@ -1,0 +1,11 @@
+class CreateJoinTableItemTerm < ActiveRecord::Migration[7.0]
+  def change
+    create_join_table :items, :terms do |t|
+      t.index [:item_id, :term_id], unique: true
+      t.index [:term_id, :item_id], unique: true
+    end
+
+    add_foreign_key :items_terms, :items
+    add_foreign_key :items_terms, :terms
+  end
+end

--- a/db/migrate/20220414225809_populate_items_terms.rb
+++ b/db/migrate/20220414225809_populate_items_terms.rb
@@ -1,0 +1,19 @@
+class PopulateItemsTerms < ActiveRecord::Migration[7.0]
+  def up
+    facets = Facet.eager_load(:terms).to_a
+    Item.find_each do |item|
+      item_terms = []
+      facets.each do |facet|
+        next unless (facet_val = item.send(facet.name.downcase))
+        facet_term_vals = facet_val.split(',').map(&:strip)
+        facet_terms = facet_term_vals.map { |v| Term.find_by(facet: facet, value: v) }
+        item_terms.concat(facet_terms)
+      end
+      item.terms = item_terms
+    end
+  end
+
+  def down
+    Term.find_each { |term| term.items.clear }
+  end
+end

--- a/db/migrate/20220415173214_drop_facet_attributes.rb
+++ b/db/migrate/20220415173214_drop_facet_attributes.rb
@@ -1,0 +1,32 @@
+class DropFacetAttributes < ActiveRecord::Migration[7.0]
+  def up
+    remove_columns :items, :colors, :size, :decade, :genre, :medium
+  end
+
+  def down
+    add_column :items, :colors, :string
+    add_column :items, :size, :string
+    add_column :items, :decade, :string
+    add_column :items, :genre, :string
+    add_column :items, :medium, :string
+
+    facets_by_id = Facet.eager_load(:terms).each_with_object({}) do |f, ff|
+      ff[f.id] = f
+    end
+
+    Item.eager_load(:terms).find_each do |item|
+      term_vals_by_facet = item.terms.each_with_object({}) do |t, tv|
+        facet = facets_by_id[t.facet_id]
+        (tv[facet] ||= []) << t.value
+      end
+      next if term_vals_by_facet.empty?
+
+      item_attrs = term_vals_by_facet.each_with_object({}) do |(f, tv), attrs|
+        attr_name = f.name.downcase.to_sym
+        attrs[attr_name] = tv.join(', ')
+      end
+
+      item.update!(**item_attrs)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_14_225809) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_15_173214) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,13 +27,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_14_225809) do
     t.string "artist"
     t.string "artist_url"
     t.string "date"
-    t.string "decade"
     t.string "description"
-    t.string "medium"
-    t.string "colors"
-    t.string "genre"
     t.string "dimensions"
-    t.string "size"
     t.string "series"
     t.string "mms_id"
     t.string "barcode"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_06_213252) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_14_191138) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_06_203912) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_06_213252) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "facets", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_facets_on_name", unique: true
+  end
 
   create_table "items", force: :cascade do |t|
     t.string "image"
@@ -41,4 +48,17 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_06_203912) do
     t.index ["mms_id"], name: "index_items_on_mms_id", unique: true
   end
 
+  create_table "terms", force: :cascade do |t|
+    t.string "value", null: false
+    t.bigint "facet_id", null: false
+    t.bigint "parent_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["facet_id"], name: "index_terms_on_facet_id"
+    t.index ["parent_id"], name: "index_terms_on_parent_id"
+    t.index ["value"], name: "index_terms_on_value", unique: true
+  end
+
+  add_foreign_key "terms", "facets"
+  add_foreign_key "terms", "terms", column: "parent_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_14_191138) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_14_225809) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,6 +48,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_14_191138) do
     t.index ["mms_id"], name: "index_items_on_mms_id", unique: true
   end
 
+  create_table "items_terms", id: false, force: :cascade do |t|
+    t.bigint "item_id", null: false
+    t.bigint "term_id", null: false
+    t.index ["item_id", "term_id"], name: "index_items_terms_on_item_id_and_term_id", unique: true
+    t.index ["term_id", "item_id"], name: "index_items_terms_on_term_id_and_item_id", unique: true
+  end
+
   create_table "terms", force: :cascade do |t|
     t.string "value", null: false
     t.bigint "facet_id", null: false
@@ -59,6 +66,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_14_191138) do
     t.index ["value"], name: "index_terms_on_value", unique: true
   end
 
+  add_foreign_key "items_terms", "items"
+  add_foreign_key "items_terms", "terms"
   add_foreign_key "terms", "facets"
   add_foreign_key "terms", "terms", column: "parent_id"
 end

--- a/lib/tasks/coverage.rake
+++ b/lib/tasks/coverage.rake
@@ -1,5 +1,7 @@
 desc 'Run all specs in spec directory, with coverage'
 task :coverage do
+  raise "Can't run specs; expected RAILS_ENV=\"test\", was #{Rails.env.inspect}" unless Rails.env.test?
+
   ENV['COVERAGE'] ||= 'true'
   Rake::Task[:spec].invoke
 end

--- a/spec/factories/facets.rb
+++ b/spec/factories/facets.rb
@@ -1,5 +1,17 @@
 FactoryBot.define do
   factory :facet do
     name { 'Concept' }
+
+    to_create do |instance|
+      instance.id = Facet.find_or_create_by(name: instance.name).id
+      instance.reload
+    end
+
+    %w[Colors Size Decade Genre Medium].each do |facet_name|
+      factory_name = "facet_#{facet_name.downcase}".to_sym
+      factory(factory_name) do
+        name { facet_name }
+      end
+    end
   end
 end

--- a/spec/factories/facets.rb
+++ b/spec/factories/facets.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :facet do
+    name { 'Concept' }
+  end
+end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -5,13 +5,13 @@ FactoryBot.define do
     artist { 'Minami, Keiko' }
     artist_url { 'https://en.wikipedia.org/wiki/Keiko_Minami' }
     date { '1955' }
-    decade { '1950-1959' }
+    # decade { '1950-1959' }
     description { 'Signed and numbered.' }
-    medium { 'Aquatint, Etching' }
-    colors { 'Color' }
-    genre { 'Landscape' }
+    # medium { 'Aquatint, Etching' }
+    # colors { 'Color' }
+    # genre { 'Landscape' }
     dimensions { '19 x 20"' }
-    size { 'Medium' }
+    # size { 'Medium' }
     series { '"16/50"' }
     mms_id { '991051069589706532' }
     barcode { 'C091134068' }
@@ -22,19 +22,30 @@ FactoryBot.define do
     notes { '17358704' }
     reserve_date { '2019-09-10' }
 
+    terms do
+      [
+        association(:term_color),
+        association(:term_medium),
+        association(:term_1950_1959),
+        association(:term_landscape),
+        association(:term_aquatint),
+        association(:term_etching)
+      ]
+    end
+
     factory :item_reyes, aliases: %i[nil_circulation nil_location nil_notes] do
       image { 'Reyes (Eastern Sierras Color).jpg' }
       title { 'Eastern Sierras (Color)' }
       artist { 'Reyes, Fernando' }
       artist_url { 'http://www.freyesart.com/about/' }
       date { '2000' }
-      decade { 'After 1999' }
+      # decade { 'After 1999' }
       description { 'Signed and numbered.' }
-      medium { 'Woodcut' }
-      colors { 'Color' }
-      genre { 'Landscape' }
+      # medium { 'Woodcut' }
+      # colors { 'Color' }
+      # genre { 'Landscape' }
       dimensions { '15.5 x 17.5"' }
-      size { 'Small' }
+      # size { 'Small' }
       series { '"13/20"' }
       mms_id { '991078545009706532' }
       barcode { 'C094893488' }
@@ -44,6 +55,16 @@ FactoryBot.define do
       appraisal_date { '2006' }
       notes { nil }
       reserve_date { '2019-08-28' }
+
+      terms do
+        [
+          association(:term_color),
+          association(:term_small),
+          association(:term_after_1999),
+          association(:term_landscape),
+          association(:term_woodcut)
+        ]
+      end
     end
 
     factory :item_moore, aliases: %i[nil_mms_id nil_reserve_date] do
@@ -52,13 +73,13 @@ FactoryBot.define do
       artist { 'Moore, Henry' }
       artist_url { 'https://en.wikipedia.org/wiki/Henry_Moore' }
       date { '1957' }
-      decade { '1950-1959' }
+      # decade { '1950-1959' }
       description { 'Signed and numbered. Severe lightstaining, Cramer 37, published by Berggruen & Cie and printed by Mourlot.' }
-      medium { 'Lithograph' }
-      colors { 'Color' }
-      genre { 'Figurative' }
+      # medium { 'Lithograph' }
+      # colors { 'Color' }
+      # genre { 'Figurative' }
       dimensions { '27.5 x 21.5"' }
-      size { 'Medium' }
+      # size { 'Medium' }
       series { '"8/200"' }
       mms_id { nil }
       barcode { 'c093329406' }
@@ -68,6 +89,16 @@ FactoryBot.define do
       appraisal_date { '2006' }
       notes { '17740940, b16398202' }
       reserve_date { nil }
+
+      terms do
+        [
+          association(:term_color),
+          association(:term_medium),
+          association(:term_1950_1959),
+          association(:term_figurative),
+          association(:term_lithograph)
+        ]
+      end
     end
   end
 end

--- a/spec/factories/terms.rb
+++ b/spec/factories/terms.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :term do
+    value { 'Empiricism' }
+
+    after(:build) do |term|
+      term.facet ||= (Facet.take || create(:facet))
+    end
+  end
+end

--- a/spec/factories/terms.rb
+++ b/spec/factories/terms.rb
@@ -2,8 +2,311 @@ FactoryBot.define do
   factory :term do
     value { 'Empiricism' }
 
-    after(:build) do |term|
-      term.facet ||= (Facet.take || create(:facet))
+    association :facet
+
+    to_create do |instance|
+      instance.id = Term.find_or_create_by(
+        facet: instance.facet,
+        value: instance.value,
+        parent: instance.parent
+      ).id
+      instance.reload
+    end
+
+    factory(:term_color) do
+      value { 'Color' }
+      facet { association :facet_colors }
+    end
+
+    factory(:term_black_and_white) do
+      value { 'Black and White' }
+      facet { association :facet_colors }
+    end
+
+    factory(:term_small) do
+      value { 'Small' }
+      facet { association :facet_size }
+    end
+
+    factory(:term_medium) do
+      value { 'Medium' }
+      facet { association :facet_size }
+    end
+
+    factory(:term_large) do
+      value { 'Large' }
+      facet { association :facet_size }
+    end
+
+    factory(:term_oversized) do
+      value { 'Oversized' }
+      facet { association :facet_size }
+    end
+
+    factory(:term_before_1900) do
+      value { 'Before 1900' }
+      facet { association :facet_decade }
+    end
+
+    factory(:term_1900_1909) do
+      value { '1900-1909' }
+      facet { association :facet_decade }
+    end
+
+    factory(:term_1910_1919) do
+      value { '1910-1919' }
+      facet { association :facet_decade }
+    end
+
+    factory(:term_1920_1929) do
+      value { '1920-1929' }
+      facet { association :facet_decade }
+    end
+
+    factory(:term_1930_1939) do
+      value { '1930-1939' }
+      facet { association :facet_decade }
+    end
+
+    factory(:term_1940_1949) do
+      value { '1940-1949' }
+      facet { association :facet_decade }
+    end
+
+    factory(:term_1950_1959) do
+      value { '1950-1959' }
+      facet { association :facet_decade }
+    end
+
+    factory(:term_1960_1969) do
+      value { '1960-1969' }
+      facet { association :facet_decade }
+    end
+
+    factory(:term_1970_1979) do
+      value { '1970-1979' }
+      facet { association :facet_decade }
+    end
+
+    factory(:term_1980_1989) do
+      value { '1980-1989' }
+      facet { association :facet_decade }
+    end
+
+    factory(:term_1990_1999) do
+      value { '1990-1999' }
+      facet { association :facet_decade }
+    end
+
+    factory(:term_after_1999) do
+      value { 'After 1999' }
+      facet { association :facet_decade }
+    end
+
+    factory(:term_no_date) do
+      value { 'No Date' }
+      facet { association :facet_decade }
+    end
+
+    factory(:term_abstract) do
+      value { 'Abstract' }
+      facet { association :facet_genre }
+    end
+
+    factory(:term_animals) do
+      value { 'Animals' }
+      facet { association :facet_genre }
+    end
+
+    factory(:term_cityscape) do
+      value { 'Cityscape' }
+      facet { association :facet_genre }
+    end
+
+    factory(:term_figurative) do
+      value { 'Figurative' }
+      facet { association :facet_genre }
+    end
+
+    factory(:term_landscape) do
+      value { 'Landscape' }
+      facet { association :facet_genre }
+    end
+
+    factory(:term_pop_art) do
+      value { 'Pop Art' }
+      facet { association :facet_genre }
+    end
+
+    factory(:term_religious) do
+      value { 'Religious' }
+      facet { association :facet_genre }
+    end
+
+    factory(:term_still_life) do
+      value { 'Still Life' }
+      facet { association :facet_genre }
+    end
+
+    factory(:term_text_based) do
+      value { 'Text Based' }
+      facet { association :facet_genre }
+    end
+
+    factory(:term_collage) do
+      value { 'Collage' }
+      facet { association :facet_medium }
+    end
+
+    factory(:term_giclée) do
+      value { 'Giclée' }
+      facet { association :facet_medium }
+    end
+
+    factory(:term_intaglio) do
+      value { 'Intaglio' }
+      facet { association :facet_medium }
+    end
+
+    factory(:term_mixed_media) do
+      value { 'Mixed Media' }
+      facet { association :facet_medium }
+    end
+
+    factory(:term_monoprint) do
+      value { 'Monoprint' }
+      facet { association :facet_medium }
+    end
+
+    factory(:term_monotype) do
+      value { 'Monotype' }
+      facet { association :facet_medium }
+    end
+
+    factory(:term_painting) do
+      value { 'Painting' }
+      facet { association :facet_medium }
+    end
+
+    factory(:term_photograph) do
+      value { 'Photograph' }
+      facet { association :facet_medium }
+    end
+
+    factory(:term_planographic) do
+      value { 'Planographic' }
+      facet { association :facet_medium }
+    end
+
+    factory(:term_relief) do
+      value { 'Relief' }
+      facet { association :facet_medium }
+    end
+
+    factory(:term_stencil) do
+      value { 'Stencil' }
+      facet { association :facet_medium }
+    end
+
+    factory(:term_unidentified) do
+      value { 'Unidentified' }
+      facet { association :facet_medium }
+    end
+
+    factory(:term_aquatint) do
+      value { 'Aquatint' }
+      facet { association :facet_medium }
+      parent { association :term_intaglio }
+    end
+
+    factory(:term_drypoint) do
+      value { 'Drypoint' }
+      facet { association :facet_medium }
+      parent { association :term_intaglio }
+    end
+
+    factory(:term_engraving) do
+      value { 'Engraving' }
+      facet { association :facet_medium }
+      parent { association :term_intaglio }
+    end
+
+    factory(:term_etching) do
+      value { 'Etching' }
+      facet { association :facet_medium }
+      parent { association :term_intaglio }
+    end
+
+    factory(:term_mezzotint) do
+      value { 'Mezzotint' }
+      facet { association :facet_medium }
+      parent { association :term_intaglio }
+    end
+
+    factory(:term_photoprint) do
+      value { 'Photoprint' }
+      facet { association :facet_medium }
+      parent { association :term_intaglio }
+    end
+
+    factory(:term_relief_etching) do
+      value { 'Relief Etching' }
+      facet { association :facet_medium }
+      parent { association :term_intaglio }
+    end
+
+    factory(:term_lithograph) do
+      value { 'Lithograph' }
+      facet { association :facet_medium }
+      parent { association :term_planographic }
+    end
+
+    factory(:term_photolithograph) do
+      value { 'Photolithograph' }
+      facet { association :facet_medium }
+      parent { association :term_planographic }
+    end
+
+    factory(:term_zincograph) do
+      value { 'Zincograph' }
+      facet { association :facet_medium }
+      parent { association :term_planographic }
+    end
+
+    factory(:term_collagraph) do
+      value { 'Collagraph' }
+      facet { association :facet_medium }
+      parent { association :term_relief }
+    end
+
+    factory(:term_linocut) do
+      value { 'Linocut' }
+      facet { association :facet_medium }
+      parent { association :term_relief }
+    end
+
+    factory(:term_wood_engraving) do
+      value { 'Wood Engraving' }
+      facet { association :facet_medium }
+      parent { association :term_relief }
+    end
+
+    factory(:term_woodcut) do
+      value { 'Woodcut' }
+      facet { association :facet_medium }
+      parent { association :term_relief }
+    end
+
+    factory(:term_serigraph) do
+      value { 'Serigraph' }
+      facet { association :facet_medium }
+      parent { association :term_stencil }
+    end
+
+    factory(:term_silkscreen) do
+      value { 'Silkscreen' }
+      facet { association :facet_medium }
+      parent { association :term_stencil }
     end
   end
 end

--- a/spec/models/facet_spec.rb
+++ b/spec/models/facet_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe Facet do
+  describe :name do
+
+    it 'must have a name' do
+      facet = create(:facet)
+      expect(facet).to be_a(Facet)
+      expect(facet).to be_valid # just to be sure
+
+      facet.name = nil
+      expect(facet).not_to be_valid
+    end
+
+    it 'must have a unique name' do
+      facet = create(:facet)
+      other_facet = Facet.new(name: facet.name)
+      expect(other_facet).not_to be_valid
+    end
+
+  end
+end

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe Term do
+  it 'must have a value' do
+    term = create(:term)
+    expect(term).to be_a(Term)
+    expect(term).to be_valid # just to be sure
+
+    term.value = nil
+    expect(term).not_to be_valid
+  end
+
+  describe :facet do
+    it 'has a facet' do
+      term = create(:term)
+      expect(term.facet).to be_a(Facet)
+    end
+
+    it 'must have a facet' do
+      term = create(:term)
+      term.facet = nil
+      expect(term).not_to be_valid
+    end
+  end
+
+  describe :parent do
+
+    it 'need not have a parent' do
+      term = create(:term)
+      expect(term.parent).to be_nil
+    end
+
+    it 'can have a parent' do
+      parent_term = create(:term)
+      child_term = create(:term, value: 'Positivism', parent: parent_term)
+      expect(child_term.parent).to eq(parent_term)
+      expect(parent_term.children).to include(child_term)
+    end
+
+    it 'cannot have a parent in a different facet' do
+      term = create(:term)
+      other_facet = create(:facet, name: "Not #{term.facet.name}")
+      other_term = create(:term, value: "Not #{term.value}", facet: other_facet)
+      term.parent = other_term
+      expect(term).not_to be_valid
+    end
+
+  end
+end

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -24,7 +24,6 @@ describe Term do
   end
 
   describe :parent do
-
     it 'need not have a parent' do
       term = create(:term)
       expect(term.parent).to be_nil
@@ -44,6 +43,32 @@ describe Term do
       term.parent = other_term
       expect(term).not_to be_valid
     end
+  end
 
+  describe :children do
+    before do
+      FactoryBot.factories.select { |f| f.build_class == Term }.each { |f| create(f.name) }
+    end
+
+    it 'can have children' do
+      facet_medium = Facet.find_by!(name: 'Medium')
+      term_intaglio = Term.find_by(value: 'Intaglio', facet: facet_medium)
+
+      children = term_intaglio.children
+      expected_values = [
+        'Aquatint',
+        'Drypoint',
+        'Engraving',
+        'Etching',
+        'Mezzotint',
+        'Photoprint',
+        'Relief Etching'
+      ]
+      expect(children.pluck(:value)).to contain_exactly(*expected_values)
+      children.each do |child|
+        expect(child.parent).to eq(term_intaglio)
+        expect(child.facet).to eq(facet_medium)
+      end
+    end
   end
 end

--- a/spec/requests/facets_spec.rb
+++ b/spec/requests/facets_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'Facets', type: :request do
+  before do
+    # creating the terms creates the facets by side effect
+    FactoryBot.factories.select { |f| f.build_class == Term }.each { |f| create(f.name) }
+  end
+
+  describe 'reading' do
+    describe :index do
+      it 'returns the facets' do
+        get facets_url
+
+        expect(response).to be_successful
+        expect(response.content_type).to start_with(JSONAPI::MEDIA_TYPE)
+
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response).to contain_jsonapi_for(Facet.all, { include: [:terms] })
+      end
+    end
+  end
+end

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Items', type: :request do
   before do
     # misusing an internal API, but what can you do?
     # https://github.com/thoughtbot/factory_bot/issues/1534
-    FactoryBot.factories.each { |f| create(f.name) if f.build_class == Item }
+    FactoryBot.factories.select { |f| f.build_class == Item }.each { |f| create(f.name) }
   end
 
   describe 'reading' do
@@ -52,13 +52,13 @@ RSpec.describe 'Items', type: :request do
         artist: 'Vieira da Silva, Maria Elena',
         artist_url: 'https://en.wikipedia.org/wiki/Maria_Helena_Vieira_da_Silva',
         date: '1959',
-        decade: '1950-1959',
+        # decade: '1950-1959',
         description: 'Annotated "Epreuve d\'artiste."',
-        medium: 'Serigraph',
-        colors: 'Color',
-        genre: 'Still Life',
+        # medium: 'Serigraph',
+        # colors: 'Color',
+        # genre: 'Still Life',
         dimensions: '19 x 15"',
-        size: 'Small',
+        # size: 'Small',
         series: 'Artist\'s Proof',
         mms_id: '991051333089706532',
         barcode: 'c093329284',

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -49,16 +49,12 @@ RSpec.describe 'Items', type: :request do
         parsed_response = JSON.parse(response.body)
         data = parsed_response['data']
 
-        relationships = data['relationships']
-        terms_relationship = relationships['terms']
-        terms_data = terms_relationship['data']
+        terms_data = data['relationships']['terms']['data']
 
         expected_count = item.terms.count
         expect(expected_count).to be > 0 # just to be sure
 
         expect(terms_data).to be_a(Array)
-        expect(terms_data.size).to eq(expected_count)
-
         expected_terms_data = item.terms.map { |t| { 'type' => 'term', 'id' => t.id.to_s } }
         expect(terms_data).to contain_exactly(*expected_terms_data)
       end

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -19,11 +19,7 @@ RSpec.describe 'Items', type: :request do
 
         parsed_response = JSON.parse(response.body)
         expect(parsed_response).to be_a(Hash)
-
-        data = parsed_response['data']
-
-        expected_json = Item.all.map { |i| jsonapi_for(i) }
-        expect(data).to match_array(expected_json)
+        expect(parsed_response).to contain_jsonapi_for(Item.all)
       end
     end
 
@@ -38,8 +34,7 @@ RSpec.describe 'Items', type: :request do
         parsed_response = JSON.parse(response.body)
         expect(parsed_response).to be_a(Hash)
 
-        data = parsed_response['data']
-        expect(data).to contain_jsonapi_for(item)
+        expect(parsed_response).to contain_jsonapi_for(item)
       end
 
       it 'includes the terms' do
@@ -111,13 +106,13 @@ RSpec.describe 'Items', type: :request do
             expect(response.content_type).to start_with(JSONAPI::MEDIA_TYPE)
 
             parsed_response = JSON.parse(response.body)
-            response_data = parsed_response['data']
+            item_id = parsed_response['data']['id'].to_i
 
-            item = Item.find(response_data['id'].to_i)
+            item = Item.find(item_id)
             expect(item).not_to be_nil
             valid_attributes.each { |attr, val| expect(item.send(attr)).to eq(val) }
 
-            expect(response_data).to contain_jsonapi_for(item)
+            expect(parsed_response).to contain_jsonapi_for(item)
             expect(response.headers['Location']).to eq(item_url(item))
           end
 
@@ -138,9 +133,8 @@ RSpec.describe 'Items', type: :request do
 
             expect(response).to have_http_status(:created)
             parsed_response = JSON.parse(response.body)
-            response_data = parsed_response['data']
 
-            item = Item.find(response_data['id'].to_i)
+            item = Item.find(parsed_response['data']['id'].to_i)
             expect(item.terms).to contain_exactly(*expected_terms)
           end
 
@@ -154,13 +148,13 @@ RSpec.describe 'Items', type: :request do
             expect(response.content_type).to start_with(JSONAPI::MEDIA_TYPE)
 
             parsed_response = JSON.parse(response.body)
-            response_data = parsed_response['data']
+            item_id = parsed_response['data']['id'].to_i
 
-            item = Item.find(response_data['id'].to_i)
+            item = Item.find(item_id)
             expect(item).not_to be_nil
             attributes.each { |attr, val| expect(item.send(attr)).to eq(val) }
 
-            expect(response_data).to contain_jsonapi_for(item)
+            expect(parsed_response).to contain_jsonapi_for(item)
             expect(response.headers['Location']).to eq(item_url(item))
           end
         end
@@ -247,8 +241,8 @@ RSpec.describe 'Items', type: :request do
             item.reload
             old_attributes.merge(new_attributes).each { |attr, val| expect(item.send(attr)).to eq(val), "Wrong value for #{attr}" }
 
-            response_data = JSON.parse(response.body)['data']
-            expect(response_data).to contain_jsonapi_for(item)
+            parsed_response = JSON.parse(response.body)
+            expect(parsed_response).to contain_jsonapi_for(item)
           end
         end
 

--- a/spec/requests/terms_spec.rb
+++ b/spec/requests/terms_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'Terms', type: :request do
+  before do
+    FactoryBot.factories.select { |f| f.build_class == Term }.each { |f| create(f.name) }
+  end
+
+  describe 'reading' do
+    describe :index do
+      it 'returns the terms' do
+        get terms_url
+
+        expect(response).to be_successful
+        expect(response.content_type).to start_with(JSONAPI::MEDIA_TYPE)
+
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response).to contain_jsonapi_for(Term.all)
+      end
+    end
+  end
+end

--- a/spec/serializers/facet_serializer_spec.rb
+++ b/spec/serializers/facet_serializer_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe FacetSerializer do
+  before do
+    # creating the terms creates the facets by side effect
+    FactoryBot.factories.select { |f| f.build_class == Term }.each { |f| create(f.name) }
+  end
+
+  it 'serializes a facet' do
+    facet = create(:facet)
+    expected_hash = {
+      data: {
+        id: facet.id.to_s,
+        type: :facet,
+        attributes: { name: facet.name },
+        relationships: {
+          terms: {
+            data: facet.terms.map { |t| { id: t.id.to_s, type: :term } }
+          }
+        }
+      }
+    }
+
+    serializer = FacetSerializer.new(facet)
+    actual_hash = serializer.serializable_hash
+    expect(actual_hash).to deep_eq_hash(expected_hash)
+  end
+
+  it 'can include the terms' do
+    facet = create(:facet_medium)
+    serializer = FacetSerializer.new(facet, { include: [:terms] })
+    actual_hash = serializer.serializable_hash
+
+    expected_includes = facet.terms.map { |t| TermSerializer.new(t).serializable_hash[:data] }
+    actual_includes = actual_hash[:included]
+    expect(actual_includes.size).to eq(expected_includes.size)
+    expected_includes.each_with_index do |incl, i|
+      expect(actual_includes[i]).to deep_eq_hash(incl)
+    end
+  end
+end

--- a/spec/serializers/item_serializer_spec.rb
+++ b/spec/serializers/item_serializer_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe ItemSerializer do
+  it 'serializes an item' do
+    item = create(:item)
+    expected_hash = {
+      data: {
+        id: item.id.to_s,
+        type: :item,
+        attributes: Item::DATA_ATTRS.to_h { |attr| [attr, item.send(attr)] },
+        relationships: {
+          terms: {
+            data: item.terms.map { |t| { id: t.id.to_s, type: :term } }
+          }
+        }
+      }
+    }
+
+    serializer = ItemSerializer.new(item)
+    actual_hash = serializer.serializable_hash
+
+    expect(actual_hash).to deep_eq_hash(expected_hash)
+  end
+end

--- a/spec/serializers/term_serializer_spec.rb
+++ b/spec/serializers/term_serializer_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+describe TermSerializer do
+  before do
+    FactoryBot.factories.select { |f| f.build_class == Term }.each { |f| create(f.name) }
+  end
+
+  it 'serializes a term' do
+    term = create(:term)
+    expected_hash = {
+      data: {
+        id: term.id.to_s,
+        type: :term,
+        attributes: { value: term.value },
+        relationships: {
+          facet: {
+            data: { id: term.facet.id.to_s, type: :facet }
+          }
+        }
+      }
+    }
+
+    serializer = TermSerializer.new(term)
+    actual_hash = serializer.serializable_hash
+
+    expect(actual_hash).to deep_eq_hash(expected_hash)
+  end
+
+  it 'includes the parent if present' do
+    term = create(:term_silkscreen)
+    serializer = TermSerializer.new(term)
+    actual_hash = serializer.serializable_hash
+
+    expected_parent_hash = { data: { id: term.parent.id.to_s, type: :term } }
+    actual_parent_hash = actual_hash[:data][:relationships][:parent]
+    expect(actual_parent_hash).to deep_eq_hash(expected_parent_hash)
+  end
+
+  it 'includes the children if present' do
+    term = create(:term_stencil)
+    serializer = TermSerializer.new(term)
+    actual_hash = serializer.serializable_hash
+
+    expected_children_hash = { data: term.children.map { |t| { id: t.id.to_s, type: :term } } }
+    actual_children_hash = actual_hash[:data][:relationships][:children]
+    expect(actual_children_hash).to deep_eq_hash(expected_children_hash)
+  end
+
+  it 'can deep-include children' do
+    term = create(:term_stencil)
+    serializer = TermSerializer.new(term, { include: [:children] })
+    actual_hash = serializer.serializable_hash
+
+    expected_includes = term.children.map { |t| TermSerializer.new(t).serializable_hash[:data] }
+    actual_includes = actual_hash[:included]
+    expect(actual_includes.size).to eq(expected_includes.size)
+    expected_includes.each_with_index do |incl, i|
+      expect(actual_includes[i]).to deep_eq_hash(incl)
+    end
+  end
+end

--- a/spec/support/matchers/jsonapi_matchers.rb
+++ b/spec/support/matchers/jsonapi_matchers.rb
@@ -3,11 +3,9 @@ require_relative 'hash_diff_matcher'
 module BerkeleyLibrary
   module Matchers
 
-    def contain_jsonapi_for(expected_obj)
-      return JsonApiErrorMatcher.new(expected_obj) if expected_obj.is_a?(ActiveModel::Error)
-      return JsonApiModelMatcher.new(expected_obj) if expected_obj.is_a?(ActiveRecord::Base)
-
-      raise ArgumentError, "Don't know how to match JSONAPI for #{expected_obj}"
+    def contain_jsonapi_for(expected_obj, options = {})
+      matcher_class = matcher_class_for(expected_obj)
+      matcher_class.new(expected_obj, options)
     end
 
     def jsonapi_for(expected_obj)
@@ -17,32 +15,20 @@ module BerkeleyLibrary
     class JsonApiMatcherBase < HashDiffMatcher
       attr_reader :expected_obj
 
-      def initialize(expected_obj, strict: true)
-        expected_hash = expected_hash_for(expected_obj)
+      def initialize(expected_obj, options = {}, strict: true)
+        expected_hash = expected_hash_for(expected_obj, options)
         @expected_obj = expected_obj
         super(expected_hash, strict: strict)
-      end
-
-      protected
-
-      def failure_message_base
-        "Expected JSON:API representation of #{expected_obj}, got #{actual.inspect}: "
       end
     end
 
     class JsonApiModelMatcher < JsonApiMatcherBase
-      def expected_hash_for(expected_obj)
-        raise ArgumentError, "Not an #{ActiveRecord::Base}: #{expected_obj.inspect}" unless model_like?(expected_obj)
-
-        {
-          'id' => expected_obj.id.to_s,
-          'type' => expected_obj.class.name.underscore,
-          'attributes' => expected_obj.attributes.except('id').transform_values(&:as_json)
-        }
-      end
-
-      def model_like?(expected_model)
-        %i[id attributes].all? { |attr| expected_model.respond_to?(attr) }
+      def expected_hash_for(expected_obj, options = {})
+        collection_like = JSONAPI::Rails.is_collection?(expected_obj)
+        serializer_class = JSONAPI::Rails.serializer_class(expected_obj, collection_like)
+        serializer = serializer_class.new(expected_obj, options)
+        h_raw = serializer.serializable_hash
+        JSON.parse(h_raw.to_json)
       end
     end
 
@@ -50,11 +36,11 @@ module BerkeleyLibrary
 
       attr_reader :expected_error
 
-      def initialize(expected_obj)
-        super(expected_obj, strict: false)
+      def initialize(expected_obj, options = {})
+        super(expected_obj, options, strict: false)
       end
 
-      def expected_hash_for(expected_error)
+      def expected_hash_for(expected_error, _options = {})
         raise ArgumentError, "Not an #{ActiveModel::Error}: #{expected_error.inspect}" unless validation_error_like?(expected_error)
 
         {
@@ -67,5 +53,16 @@ module BerkeleyLibrary
         %i[type attribute].all? { |attr| expected_error.respond_to?(attr) }
       end
     end
+
+    private
+
+    def matcher_class_for(expected_obj)
+      test_val = expected_obj.respond_to?(:first) ? expected_obj.first : expected_obj
+      return JsonApiErrorMatcher if test_val.is_a?(ActiveModel::Error)
+      return JsonApiModelMatcher if test_val.is_a?(ActiveRecord::Base)
+
+      raise ArgumentError, "Don't know how to match JSONAPI for #{expected_obj}"
+    end
+
   end
 end


### PR DESCRIPTION
Moves controlled vocabularies from `items` table and `Item` model to separate `terms`/`Term` and `facets`/`Facet` models. Adds controllers and API methods for facets and terms.