### PR TITLE
AP-416: Use berkeleyEduAlternateID in CAS callback

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User
         debug: 'omniauth',
         uid: auth_extra['uid'],
         display_name: auth_extra['displayName'],
-        email: auth_extra['berkeleyEduOfficialEmail'],
+        email: auth_extra['berkeleyEduAlternateID'],
         galc_admin: galc_admin?(auth_extra['berkeleyEduIsMemberOf'])
       )
     end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
 #    platform: linux/amd64
     depends_on:
       - db
+    environment:
+      - SERVE_TEST_UI=${SERVE_TEST_UI:-true}
     init: true
     networks:
       default:

--- a/public/index.html
+++ b/public/index.html
@@ -1,28 +1,24 @@
 <!DOCTYPE html>
-<!--suppress HtmlUnknownTarget, CheckTagEmptyBody -->
-<!--suppress JSUnresolvedLibraryURL, CheckTagEmptyBody -->
+<!--suppress HtmlUnknownTarget -->
 <html lang="en">
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <title>Graphic Arts Loan Collection</title>
+    <title>(PREVIEW) Graphic Arts Loan Collection</title>
     <link rel="stylesheet" media="all" href="https://use.fontawesome.com/releases/v5.13.1/css/all.css" />
     <link rel="stylesheet" media="all" href="https://use.fontawesome.com/releases/v5.13.1/css/v4-shims.css" />
     <link rel="stylesheet" media="all" href="https://use.typekit.net/ooq8hdx.css" />
-    <link rel="stylesheet" media="all" href="https://www.lib.berkeley.edu/sites/default/files/css/css_9m8-tA3IQf8ThlLQYTTZUyEweCvyR908Tg0XCbKYOfY.css" />
-    <link rel="stylesheet" media="all" href="https://www.lib.berkeley.edu/sites/default/files/css/css_yD1SqggTrO1FYCweGgM0u_33oDUc944jLYToRLwcGyg.css" />
-    <link rel="stylesheet" media="all" href="https://www.lib.berkeley.edu/sites/default/files/css/css_whd13hgPHsqBVOBFppmRAkBFQYuiBvZ8wd1eo7cTe-M.css" />
-
-    <link rel="stylesheet" media="all" href="https://unpkg.com/%40berkeleylibrary/galc-ui%40snapshot/dist/style.css" />
-    <script type="module" src="https://unpkg.com/%40berkeleylibrary/galc-ui%40snapshot/dist/galc-ui.umd.js"></script>
+    <link rel="stylesheet" media="all" href="https://www.lib.berkeley.edu/themes/custom/ucblibrary/css/style.css" />
+    <link rel="stylesheet" media="all" href="https://unpkg.com/@berkeleylibrary/galc-ui@snapshot/dist/style.css">
+    <script type="module" src="https://unpkg.com/%40berkeleylibrary/galc-ui%40snapshot"></script>
 </head>
-<body class="user-logged-in">
-<main>
-    <div class="layout-content">
-        <div class="region region-content">
-            <div id="galc-app" data-api-base-url="https://galc-api.ucblib.org" class="block-views"></div>
+<body>
+    <main>
+        <div class="layout-content">
+            <div class="region region-content">
+                <div id="galc-app" data-api-base-url="http://localhost:3000" class="block-views"></div>
+            </div>
         </div>
-    </div>
-</main>
+    </main>
 </body>
 </html>

--- a/spec/data/cas/5551212.xml
+++ b/spec/data/cas/5551212.xml
@@ -6,7 +6,7 @@
       <cas:uid>5551212</cas:uid>
       <cas:berkeleyEduIsMemberOf>cn=edu:berkeley:official:all-accounts-people-ou,ou=campus groups,dc=berkeley,dc=edu</cas:berkeleyEduIsMemberOf>
       <cas:berkeleyEduAffiliations>STUDENT-TYPE-REGISTERED</cas:berkeleyEduAffiliations>
-      <cas:berkeleyEduOfficialEmail>jdoe@berkeley.test</cas:berkeleyEduOfficialEmail>
+      <cas:berkeleyEduAlternateID>jdoe-alt@berkeley.test</cas:berkeleyEduAlternateID>
     </cas:attributes>
   </cas:authenticationSuccess>
 </cas:serviceResponse>

--- a/spec/data/cas/5551215.xml
+++ b/spec/data/cas/5551215.xml
@@ -6,7 +6,7 @@
             <cas:berkeleyEduIsMemberOf>cn=edu:berkeley:official:all-accounts-people-ou,ou=campus groups,dc=berkeley,dc=edu</cas:berkeleyEduIsMemberOf>
             <cas:berkeleyEduIsMemberOf>cn=edu:berkeley:org:libr:galc:galc-admins,ou=campus groups,dc=berkeley,dc=edu</cas:berkeleyEduIsMemberOf>
             <cas:berkeleyEduAffiliations>EMPLOYEE-TYPE-STAFF</cas:berkeleyEduAffiliations>
-            <cas:berkeleyEduOfficialEmail>rroe@berkeley.test</cas:berkeleyEduOfficialEmail>
+            <cas:berkeleyEduAlternateID>rroe-alt@berkeley.test</cas:berkeleyEduAlternateID>
         </cas:attributes>
     </cas:authenticationSuccess>
 </cas:serviceResponse>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,7 +17,7 @@ describe User do
         'extra' => {
           'uid' => '5551215',
           'displayName' => 'Rachel Roe',
-          'berkeleyEduOfficialEmail' => 'rroe@berkeley.test',
+          'berkeleyEduAlternateID' => 'rroe-alt@berkeley.test',
           'berkeleyEduIsMemberOf' => [
             'cn=edu:berkeley:org:libr:galc:galc-admins,ou=campus groups,dc=berkeley,dc=edu'
           ]
@@ -30,7 +30,7 @@ describe User do
         'extra' => {
           'uid' => '5551212',
           'displayName' => 'Jane Doe',
-          'berkeleyEduOfficialEmail' => 'jdoe@berkeley.test',
+          'berkeleyEduAlternateID' => 'jdoe-alt@berkeley.test',
           'berkeleyEduIsMemberOf' => [
             'cn=edu:berkeley:official:all,ou=campus groups,dc=berkeley,dc=edu'
           ]
@@ -44,7 +44,7 @@ describe User do
       expect(user).to be_galc_admin
       expect(user.uid).to eq('5551215')
       expect(user.display_name).to eq('Rachel Roe')
-      expect(user.email).to eq('rroe@berkeley.test')
+      expect(user.email).to eq('rroe-alt@berkeley.test')
     end
 
     it 'determines admin status based on CalGroups' do
@@ -53,7 +53,7 @@ describe User do
       expect(user).not_to be_galc_admin
       expect(user.uid).to eq('5551212')
       expect(user.display_name).to eq('Jane Doe')
-      expect(user.email).to eq('jdoe@berkeley.test')
+      expect(user.email).to eq('jdoe-alt@berkeley.test')
     end
   end
 

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe AuthController, type: :request do
 
   describe 'GET /' do
     it 'returns 404 Not Found' do
+      allow(ENV).to receive(:[]).with('SERVE_TEST_UI').and_return(nil)
       get root_path
       expect(response).to have_http_status(:not_found)
     end
@@ -97,7 +98,7 @@ RSpec.describe AuthController, type: :request do
         expected_attrs = {
           uid: '5551215',
           display_name: 'Rachel Roe',
-          email: 'rroe@berkeley.test',
+          email: 'rroe-alt@berkeley.test',
           galc_admin: true
         }
 


### PR DESCRIPTION
Updates user initialization code in the CAS callback to use the new `berkeleyEduAlternateID` instead of the deprecated `berkeleyEduOfficialEmail`. This is a one-liner change in the actual codebase, but with a few more references in the tests.

Note that I opted to completely remove references to berkeleyEduOfficialEmail, because 1) although CalNet is currently sending both, they will eventually remove it, and 2) this should minimize confusion down the road, in case a developer wonders why we reference both but only use one.

Additionally, I found it hard to test because the SERVE_TEST_UI flag / feature was broken. I've updated index.html to make that work (pinned to galc-ui@snapshot). I recognize that's not directly related to this change, however, so I'm happy to remove it.