### PR TITLE
Bump release tag-push action to v2.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Tag and push image
-        uses: akhilerm/tag-push-action@v2
+        uses: akhilerm/tag-push-action@v2.1.0
         with:
           src: ${{ env.BUILD_IMAGE }}
           dst: |


### PR DESCRIPTION
Bumps the akhilerm/tag-push-action, which is used to tag and push released docker images, to v2.1.0. This was previously pinned to v2 but that moving tag is no longer supported.